### PR TITLE
converts NSNull, NSArray, NSDictionary, NSDate and NSData

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ function Runtime() {
     let cachedNSNumberCtor = null;
     let cachedNSNumberBoolean = null;
     let cachedNSNumberBooleanCtor = null;
+    let cachedNSArray = null;
+    let cachedNSDictionary = null;
     let cachedNSMutableArray = null;
     let cachedNSMutableArrayCtor = null;
     let cachedNSMutableDictionary = null;
@@ -461,11 +463,11 @@ function Runtime() {
             if (cachedNSString === null) {
                 cachedNSString = classRegistry.NSString;
             }
-            if (cachedNSMutableArray === null) {
-                cachedNSMutableArray = classRegistry.NSMutableArray;
+            if (cachedNSArray === null) {
+                cachedNSArray = classRegistry.NSArray;
             }
-            if (cachedNSMutableDictionary === null) {
-                cachedNSMutableDictionary = classRegistry.NSMutableDictionary;
+            if (cachedNSDictionary === null) {
+                cachedNSDictionary = classRegistry.NSDictionary;
             }
             if (cachedNSDate === null) {
                 cachedNSDate = classRegistry.NSDate;
@@ -487,7 +489,7 @@ function Runtime() {
                 const toStringImpl = o.UTF8String;
                 return toStringImpl.call(o);
             }
-            else if (cachedIsKindOfClass.call(o, cachedNSMutableArray)) {
+            else if (cachedIsKindOfClass.call(o, cachedNSArray)) {
                 const arr = [];
                 const count = o.count().valueOf();
                 const objectAtIndexImpl = o.objectAtIndex_;
@@ -497,7 +499,7 @@ function Runtime() {
                 }
                 return arr;
             }
-            else if (cachedIsKindOfClass.call(o, cachedNSMutableDictionary)) {
+            else if (cachedIsKindOfClass.call(o, cachedNSDictionary)) {
                 const dict = {};
                 const enumerator = o.keyEnumerator();
                 const objectForKeyImpl = o.objectForKey_;

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function Runtime() {
     let cachedNSDate = null;
     let cachedNSDateCtor = null;
     let cachedNSData = null;
+    let cachedNSNull = null;
     let cachedNSNullInstance = null;
     let singularTypeById = null;
     const PRIV = Symbol('priv');
@@ -472,6 +473,9 @@ function Runtime() {
             if (cachedNSData === null) {
                 cachedNSData = classRegistry.NSData;
             }
+            if (cachedNSNull === null) {
+                cachedNSNull = classRegistry.NSNull;
+            }
             if (cachedIsKindOfClass === null) {
                 cachedIsKindOfClass = classRegistry.NSObject.isKindOfClass_;
             }
@@ -509,6 +513,9 @@ function Runtime() {
             }
             else if (cachedIsKindOfClass.call(o, cachedNSData)) {
                 return o.bytes().readByteArray(o.length());
+            }
+            else if (cachedIsKindOfClass.call(o, cachedNSNull)) {
+                return null;
             }
 
             return o.toString();

--- a/index.js
+++ b/index.js
@@ -1696,6 +1696,9 @@ function Runtime() {
             return obj;
         else if (typeof obj === 'object' && obj.hasOwnProperty('handle'))
             return obj.handle;
+        const nativeObj = toNativeId(obj, true);
+        if (typeof nativeObj === 'object' && nativeObj.hasOwnProperty('handle'))
+            return nativeObj.handle;
         else
             throw new Error("Expected NativePointer or ObjC.Object instance");
     }

--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ function Runtime() {
     let cachedNSNumberCtor = null;
     let cachedNSNumberBoolean = null;
     let cachedNSNumberBooleanCtor = null;
-    let cachedNSArray = null;
-    let cachedNSArrayCtor = null;
-    let cachedNSDictionary = null;
-    let cachedNSDictionaryCtor = null;
+    let cachedNSMutableArray = null;
+    let cachedNSMutableArrayCtor = null;
+    let cachedNSMutableDictionary = null;
+    let cachedNSMutableDictionaryCtor = null;
     let cachedNSDate = null;
     let cachedNSDateCtor = null;
     let cachedNSData = null;
@@ -461,11 +461,11 @@ function Runtime() {
             if (cachedNSString === null) {
                 cachedNSString = classRegistry.NSString;
             }
-            if (cachedNSArray === null) {
-                cachedNSArray = classRegistry.NSArray;
+            if (cachedNSMutableArray === null) {
+                cachedNSMutableArray = classRegistry.NSMutableArray;
             }
-            if (cachedNSDictionary === null) {
-                cachedNSDictionary = classRegistry.NSDictionary;
+            if (cachedNSMutableDictionary === null) {
+                cachedNSMutableDictionary = classRegistry.NSMutableDictionary;
             }
             if (cachedNSDate === null) {
                 cachedNSDate = classRegistry.NSDate;
@@ -487,7 +487,7 @@ function Runtime() {
                 const toStringImpl = o.UTF8String;
                 return toStringImpl.call(o);
             }
-            else if (cachedIsKindOfClass.call(o, cachedNSArray)) {
+            else if (cachedIsKindOfClass.call(o, cachedNSMutableArray)) {
                 const arr = [];
                 const count = o.count().valueOf();
                 const objectAtIndexImpl = o.objectAtIndex_;
@@ -497,7 +497,7 @@ function Runtime() {
                 }
                 return arr;
             }
-            else if (cachedIsKindOfClass.call(o, cachedNSDictionary)) {
+            else if (cachedIsKindOfClass.call(o, cachedNSMutableDictionary)) {
                 const dict = {};
                 const enumerator = o.keyEnumerator();
                 const objectForKeyImpl = o.objectForKey_;
@@ -2424,13 +2424,13 @@ function Runtime() {
         }
         else if (type === 'object') {
             if (v.constructor === Array) {
-                if (cachedNSArray === null) {
-                    cachedNSArray = classRegistry.NSMutableArray;
+                if (cachedNSMutableArray === null) {
+                    cachedNSMutableArray = classRegistry.NSMutableArray;
                 }
-                if (cachedNSArrayCtor === null) {
-                    cachedNSArrayCtor = cachedNSArray.array;
+                if (cachedNSMutableArrayCtor === null) {
+                    cachedNSMutableArrayCtor = cachedNSMutableArray.array;
                 }
-                let array = cachedNSArrayCtor.call(cachedNSArray);
+                let array = cachedNSMutableArrayCtor.call(cachedNSMutableArray);
                 let arrayAddObject = array.addObject_;
                 for (let i = 0; i < v.length; i++) {
                     arrayAddObject.call(array, toNativeId(v[i], true));
@@ -2438,13 +2438,13 @@ function Runtime() {
                 return array;
             }
             else if (v.constructor === Object) {
-                if (cachedNSDictionary === null) {
-                    cachedNSDictionary = classRegistry.NSMutableDictionary;
+                if (cachedNSMutableDictionary === null) {
+                    cachedNSMutableDictionary = classRegistry.NSMutableDictionary;
                 }
-                if (cachedNSDictionaryCtor === null) {
-                    cachedNSDictionaryCtor = cachedNSDictionary.dictionary;
+                if (cachedNSMutableDictionaryCtor === null) {
+                    cachedNSMutableDictionaryCtor = cachedNSMutableDictionary.dictionary;
                 }
-                let dict = cachedNSDictionaryCtor.call(cachedNSDictionary);
+                let dict = cachedNSMutableDictionaryCtor.call(cachedNSMutableDictionary);
                 let dictSetObjectForKey = dict.setObject_forKey_;
                 for (const key in v) {
                     if (v.hasOwnProperty(key)) {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function Runtime() {
     let cachedNSDate = null;
     let cachedNSDateCtor = null;
     let cachedNSData = null;
+    let cachedNSDataCtor = null;
     let cachedNSNull = null;
     let cachedNSNullInstance = null;
     let singularTypeById = null;
@@ -2425,7 +2426,28 @@ function Runtime() {
             return cachedNSNumberBooleanCtor.call(cachedNSNumberBoolean, v);
         }
         else if (type === 'object') {
-            if (v.constructor === Array) {
+            // RegExp and URL are not supported
+            if (v.constructor === Date) {
+                if (cachedNSDate === null) {
+                    cachedNSDate = classRegistry.NSDate;
+                }
+                if (cachedNSDateCtor === null) {
+                    cachedNSDateCtor = cachedNSDate.dateWithTimeIntervalSince1970_;
+                }
+                return cachedNSDateCtor.call(cachedNSDate, v.getTime());
+            }
+            else if (v.constructor === ArrayBuffer) {
+                if (cachedNSData === null) {
+                    cachedNSData = classRegistry.NSData;
+                }
+                if (cachedNSDataCtor === null) {
+                    cachedNSDataCtor = cachedNSData.dataWithBytes_length_;
+                }
+                let buf = Memory.alloc(v.byteLength);
+                buf.writeByteArray(v);
+                return cachedNSDataCtor.call(cachedNSData, buf, v.byteLength);
+            }
+            else if (v.constructor === Array) {
                 if (cachedNSMutableArray === null) {
                     cachedNSMutableArray = classRegistry.NSMutableArray;
                 }
@@ -2455,15 +2477,6 @@ function Runtime() {
                     }
                 }
                 return dict;
-            }
-            else if (v.constructor === Date) {
-                if (cachedNSDate === null) {
-                    cachedNSDate = classRegistry.NSDate;
-                }
-                if (cachedNSDateCtor === null) {
-                    cachedNSDateCtor = cachedNSDate.dateWithTimeIntervalSince1970_;
-                }
-                return cachedNSDateCtor.call(cachedNSDate, v.getTime());
             }
         }
 

--- a/test/basics.m
+++ b/test/basics.m
@@ -26,6 +26,7 @@ TESTLIST_BEGIN (basics)
   TESTENTRY (object_can_be_constructed_from_pointer)
   TESTENTRY (string_can_be_constructed)
   TESTENTRY (string_can_be_passed_as_argument)
+  TESTENTRY (plain_object_can_be_passed_as_argument)
   TESTENTRY (class_can_be_implemented)
 
   TESTGROUP_BEGIN ("Block")
@@ -348,6 +349,28 @@ TESTCASE (string_can_be_passed_as_argument)
       "str = str.stringByAppendingString_(\"Mushrooms\");"
       "send(str.toString());");
   EXPECT_SEND_MESSAGE_WITH ("\"SnakesMushrooms\"");
+}
+
+TESTCASE (plain_object_can_be_passed_as_argument)
+{
+  COMPILE_AND_LOAD_SCRIPT (
+      "var NSMutableDictionary = ObjC.classes.NSMutableDictionary;"
+      "var dict = NSMutableDictionary.dictionaryWithDictionary_({"
+        "\"Snakes\":["
+        "  \"Mushrooms\","
+        "  \"Candies\""
+        "],"
+        "\"Null\":null,"
+        "\"Number\":9120,"
+      "});"
+      "dict.addEntriesFromDictionary_({"
+        "\"Toys\":{"
+          "\"Pokemon\":{\"Yellow\":[\"Pikachu\"]},"
+          "\"Trains\":[]"
+        "}"
+      "});"
+      "send(dict.valueOf()[\"Toys\"][\"Pokemon\"][\"Yellow\"][0]+dict.valueOf()[\"Number\"]);");
+  EXPECT_SEND_MESSAGE_WITH ("\"Pikachu9120\"");
 }
 
 TESTCASE (class_can_be_implemented)

--- a/test/basics.m
+++ b/test/basics.m
@@ -26,7 +26,7 @@ TESTLIST_BEGIN (basics)
   TESTENTRY (object_can_be_constructed_from_pointer)
   TESTENTRY (string_can_be_constructed)
   TESTENTRY (string_can_be_passed_as_argument)
-  TESTENTRY (plain_object_can_be_passed_as_argument)
+  TESTENTRY (object_can_be_passed_as_argument)
   TESTENTRY (class_can_be_implemented)
 
   TESTGROUP_BEGIN ("Block")
@@ -351,7 +351,7 @@ TESTCASE (string_can_be_passed_as_argument)
   EXPECT_SEND_MESSAGE_WITH ("\"SnakesMushrooms\"");
 }
 
-TESTCASE (plain_object_can_be_passed_as_argument)
+TESTCASE (object_can_be_passed_as_argument)
 {
   COMPILE_AND_LOAD_SCRIPT (
       "var NSMutableDictionary = ObjC.classes.NSMutableDictionary;"


### PR DESCRIPTION
### Changes
- `NSString <=> string`
- `NSNumber <=> number`, but `NaN` is not allowed anymore (`Int64` and `UInt64` are not considered)
- `NSNumber <= boolean`
- `NSArray <=> Array`
- `NSDictionary <=> Object`
- `NSDate <=> Date`
- `NSData <=> ArrayBuffer`
- `NSNull <=> null` only when `null` is wrapped in `NSArray` or `NSDictionary`
- fully tested without bumping version

### Issues
- cannot detect infinite recursion
- overrides `.valueOf`, which may cause compatibility issues
- `NSRegularExpression <=> RegExp` is not implemented due to the regex syntax difference
- objc class caching needs to be improved, too many variables :-/
- writing tests with multi-line c strings drives me crazy!