### PR TITLE
Fix `- respondsToSelector:` for optional protocol methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1410,6 +1410,8 @@ function Runtime() {
                     callback.call(this);
             },
             '- respondsToSelector:': function (sel) {
+                if (selectorAsString(sel) in methods)
+                    return true;
                 return this.data.target.respondsToSelector_(sel);
             },
             '- forwardingTargetForSelector:': function (sel) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@ IOS_HOST = iphone
 IOS_ARCH = arm64
 IOS_PREFIX = /usr/local/opt/frida-objc-bridge-tests-$(IOS_ARCH)
 
-frida_version := 14.1.2
+frida_version := 15.0.15
 
 cflags := -Wall -pipe -Os -g
 ldflags := -Wl,-framework,Foundation -lfrida-gumjs -lresolv -Wl,-dead_strip

--- a/test/basics.m
+++ b/test/basics.m
@@ -45,6 +45,7 @@ TESTLIST_BEGIN (basics)
   TESTENTRY (attempt_to_read_inexistent_property_should_yield_undefined)
   TESTENTRY (proxied_method_can_be_invoked)
   TESTENTRY (proxied_method_can_be_overridden)
+  TESTENTRY (proxy_instance_responds_to_selector_for_optional_methods_works)
   TESTENTRY (methods_with_weird_names_can_be_invoked)
   TESTENTRY (method_call_preserves_value)
   TESTENTRY (method_call_can_be_traced)
@@ -837,6 +838,30 @@ TESTCASE (proxied_method_can_be_overridden)
   EXPECT_SEND_MESSAGE_WITH ("\"ready\"");
 
   g_assert_cmpint ([calc add:3], ==, 1230);
+}
+
+TESTCASE (proxy_instance_responds_to_selector_for_optional_methods_works)
+{
+  FridaDefaultCalculator * calc = [[[FridaDefaultCalculator alloc] init]
+      autorelease];
+
+  COMPILE_AND_LOAD_SCRIPT (
+      "var pool = ObjC.classes.NSAutoreleasePool.alloc().init();"
+      "var CalculatorProxy = ObjC.registerProxy({"
+        "protocols: [ObjC.protocols.FridaCalculator],"
+        "methods: {"
+          "'- magic': function () {"
+            "return 0xdeadbeef;"
+          "}"
+        "}"
+      "});"
+      "var calculatorProxy = new CalculatorProxy(" GUM_PTR_CONST ", {});"
+      "var calculator = new ObjC.Object(calculatorProxy);"
+      "var sel = ObjC.selector('- magic');"
+      "send(calculator.respondsToSelector_(sel));"
+      "pool.release();",
+      calc);
+  EXPECT_SEND_MESSAGE_WITH ("1");
 }
 
 @interface FridaTest1 : NSObject


### PR DESCRIPTION
Since proxies can implement optional methods in a protocol that the target doesn't implement (or any method in general, not necessarily a protocol-conforming one,) `- respondsToSelector:` should check that the proxy has this method before the call is forwarded to the target.