### PR TITLE
Fix `- respondsToSelector:` for optional protocol methods, take two

### DIFF
--- a/index.js
+++ b/index.js
@@ -1396,6 +1396,11 @@ function Runtime() {
         const protocols = properties.protocols || [];
         const methods = properties.methods || {};
         const events = properties.events || {};
+        const supportedSelectors = new Set(
+            Object.keys(methods)
+                .filter(m => /([+\-])\s(\S+)/.exec(m) !== null)
+                .map(m => m.split(' ')[1])
+        );
 
         const proxyMethods = {
             '- dealloc': function () {
@@ -1410,8 +1415,10 @@ function Runtime() {
                     callback.call(this);
             },
             '- respondsToSelector:': function (sel) {
-                if (selectorAsString(sel) in methods)
+                const selector = selectorAsString(sel);
+                if (supportedSelectors.has(selector))
                     return true;
+
                 return this.data.target.respondsToSelector_(sel);
             },
             '- forwardingTargetForSelector:': function (sel) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@ IOS_HOST = iphone
 IOS_ARCH = arm64
 IOS_PREFIX = /usr/local/opt/frida-objc-bridge-tests-$(IOS_ARCH)
 
-frida_version := 15.0.15
+frida_version := 15.1.2
 
 cflags := -Wall -pipe -Os -g
 ldflags := -Wl,-framework,Foundation -lfrida-gumjs -lresolv -Wl,-dead_strip

--- a/test/basics.m
+++ b/test/basics.m
@@ -857,7 +857,7 @@ TESTCASE (proxy_instance_responds_to_selector_for_optional_methods_works)
       "});"
       "var calculatorProxy = new CalculatorProxy(" GUM_PTR_CONST ", {});"
       "var calculator = new ObjC.Object(calculatorProxy);"
-      "var sel = ObjC.selector('- magic');"
+      "var sel = ObjC.selector('magic');"
       "send(calculator.respondsToSelector_(sel));"
       "pool.release();",
       calc);


### PR DESCRIPTION
Our method names are prefixed with a qualifier and a space, but the selector passed to `- respondsToSelector:` is of the "canonical" form, i.e. without our prefixes.