### PR TITLE
Ensure block structure is writable in implementation setter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1360,7 +1360,15 @@ function Runtime() {
                 signature.argTypes.map(function (arg) { return arg.type; }));
             this._callback = callback;
             const location = this.handle.add(blockOffsets.invoke);
+            const prot = Memory.queryProtection(location);
+            const writable = prot.includes('w');
+            if (!writable) {
+                Memory.protect(location, Process.pointerSize, 'rw-');
+            }
             location.writePointer(callback.strip().sign('ia', location));
+            if (!writable) {
+                Memory.protect(location, Process.pointerSize, prot);
+            }
         }
       },
       declare: {


### PR DESCRIPTION
When the target block doesn't capture any local variables and it is not the result of a copy, its structure can still be residing in a read-only section. In that case setting the block implementation causes a SIGBUS.

depends on https://github.com/frida/frida-gum/pull/779