### PR TITLE
Allow failing class_getName

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -43,7 +43,7 @@ function getApi() {
                 "objc_disposeClassPair": ['void', ['pointer']],
                 "objc_registerClassPair": ['void', ['pointer']],
                 "class_isMetaClass": ['bool', ['pointer']],
-                "class_getName": ['pointer', ['pointer']],
+                "class_getName": ['pointer', ['pointer'], { exceptions: 'steal' }],
                 "class_getImageName": ['pointer', ['pointer']],
                 "class_copyProtocolList": ['pointer', ['pointer', 'pointer']],
                 "class_copyMethodList": ['pointer', ['pointer', 'pointer']],
@@ -124,7 +124,7 @@ function getApi() {
                     if (isObjCApi)
                         signature.call(temporaryApi, exp.address);
                 } else {
-                    temporaryApi[name] = new NativeFunction(exp.address, signature[0], signature[1], defaultInvocationOptions);
+                    temporaryApi[name] = new NativeFunction(exp.address, signature[0], signature[1], signature[2] ?? defaultInvocationOptions);
                     if (isObjCApi)
                         temporaryApi[name] = temporaryApi[name];
                 }


### PR DESCRIPTION
This allows for class_getName to fail and be gracefully handled by objc-bridge. Swift version prior to 5.10 had an issue causing the process to crash when attempting to resolve names of lazily named objc-classes, which now they handle [by synthesising a placeholder name with offset](https://github.com/swiftlang/swift/commit/2f6baac55e3cd857b86c64b58375bf1e6ec33875).

