### PR TITLE
Handle extended block type encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -2238,9 +2238,8 @@ function Runtime() {
                 skipExtendedBlock(cursor);
             } else {
                 skipChar(cursor);
-                if (ch === '"') {
+                if (ch === '"')
                     readUntil('"', cursor);
-                }
             }
         }
         skipChar(cursor); // '>'

--- a/index.js
+++ b/index.js
@@ -2170,6 +2170,9 @@ function Runtime() {
             if (next === '?') {
                 id += next;
                 skipChar(cursor);
+                if (peekChar(cursor) === '<') {
+                    skipExtendedBlock(cursor);
+                }
             } else if (next === '"') {
                 skipChar(cursor);
                 readUntil('"', cursor);
@@ -2225,6 +2228,22 @@ function Runtime() {
         } else {
             throw new Error("Unable to handle type " + id);
         }
+    }
+
+    function skipExtendedBlock(cursor) {
+        let ch;
+        skipChar(cursor); // '<'
+        while ((ch = peekChar(cursor)) !== '>') {
+            if (peekChar(cursor) === '<') {
+                skipExtendedBlock(cursor);
+            } else {
+                skipChar(cursor);
+                if (ch === '"') {
+                    readUntil('"', cursor);
+                }
+            }
+        }
+        skipChar(cursor); // '>'
     }
 
     function readNumber(cursor) {


### PR DESCRIPTION
This change adds basic support for extended block type encoding. When that is enabled by the compiler, block type encodings also include the types for the arguments, enclosed in `<>` immediately following the block identifier `@?`.

Here "basic" means that now `readType()` just skips the additional type annotations of block arguments (which could be nested) instead of throwing `"Unable to handle type <"`.

The sources of truth for this are in the LLVM project and documented in C++:
- implementation (inside the `if`) : https://github.com/llvm/llvm-project/blob/bfa711a970d50c9101c8962609f9aad4f5395825/clang/lib/AST/ASTContext.cpp#L9036-L9057
- test case: https://github.com/llvm/llvm-project/blob/f07b10b7c4706735c1e206b64da4c43aaf88b6af/clang/test/CodeGenObjC/extended-block-signature-encode.m