### PR TITLE
Fix objc_msgSend undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1777,6 +1777,8 @@ function Runtime() {
             ? getMsgSendSuperImpl(signature, invocationOptions)
             : getMsgSendImpl(signature, invocationOptions);
 
+        let a = objc_msgSend + ptr("0x0");
+
         const argVariableNames = argTypes.map(function (t, i) {
             return "a" + (i + 1);
         });

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function Runtime() {
     let readObjectIsa = null;
     const msgSendBySignatureId = new Map();
     const msgSendSuperBySignatureId = new Map();
+    let markUsed = null;
     let cachedNSString = null;
     let cachedNSStringCtor = null;
     let cachedNSNumber = null;
@@ -1777,8 +1778,9 @@ function Runtime() {
             ? getMsgSendSuperImpl(signature, invocationOptions)
             : getMsgSendImpl(signature, invocationOptions);
 
-        let a = objc_msgSend + ptr("0x0");
-
+        // hack to prevent rollup from dropping objc_msgSend
+        markUsed = objc_msgSend.add("0x0");
+        
         const argVariableNames = argTypes.map(function (t, i) {
             return "a" + (i + 1);
         });


### PR DESCRIPTION
This is a bit of hack that works because `objc_msgSend` is undefined so calling any methods on ObjC objects fails. This fixes both https://github.com/frida/frida-objc-bridge/issues/64 as well as issue here inside of https://github.com/frida/frida/issues/3460.

