### PR TITLE
Clamp objc_getClassList second-call count to buffer size

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,8 +268,11 @@ function Runtime() {
                 if (numClasses !== numCachedClasses) {
                     // It's impossible to unregister classes in ObjC, so if the number of
                     // classes hasn't changed, we can assume that the list is up to date.
-                    const classHandles = Memory.alloc(numClasses * pointerSize);
-                    numClasses = api.objc_getClassList(classHandles, numClasses);
+                    const bufferSize = numClasses;
+                    const classHandles = Memory.alloc(bufferSize * pointerSize);
+                    numClasses = api.objc_getClassList(classHandles, bufferSize);
+                    if (numClasses > bufferSize)
+                        numClasses = bufferSize;
                     for (let i = 0; i !== numClasses; i++) {
                         const handle = classHandles.add(i * pointerSize).readPointer();
                         const name = api.class_getName(handle).readUtf8String();

--- a/lib/fastpaths.js
+++ b/lib/fastpaths.js
@@ -134,11 +134,13 @@ collect_subclasses (Class klass,
                     GHashTable * result)
 {
   Class * classes;
-  int count, i;
+  int count, buffer_count, i;
 
-  count = objc_getClassList (NULL, 0);
-  classes = g_malloc (count * sizeof (gpointer));
-  count = objc_getClassList (classes, count);
+  buffer_count = objc_getClassList (NULL, 0);
+  classes = g_malloc (buffer_count * sizeof (gpointer));
+  count = objc_getClassList (classes, buffer_count);
+  if (count > buffer_count)
+    count = buffer_count;
 
   for (i = 0; i != count; i++)
   {

--- a/lib/fastpaths.js
+++ b/lib/fastpaths.js
@@ -134,7 +134,7 @@ collect_subclasses (Class klass,
                     GHashTable * result)
 {
   Class * classes;
-  int count, buffer_count, i;
+  int buffer_count, count, i;
 
   buffer_count = objc_getClassList (NULL, 0);
   classes = g_malloc (buffer_count * sizeof (gpointer));


### PR DESCRIPTION
objc_getClassList returns the total number of classes, not the number written to the buffer, so a class registration racing against the call pair would make the loop read past the allocation.