### PR TITLE
api: Drop dead isObjCApi branches left from refactor

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -100,7 +100,6 @@ export function getApi() {
     ];
     let remaining = 0;
     pending.forEach(function (api) {
-        const isObjCApi = api.module === 'libobjc.A.dylib';
         const functions = api.functions || {};
         const variables = api.variables || {};
         const optionals = api.optionals || {};
@@ -120,12 +119,8 @@ export function getApi() {
                 const signature = functions[name];
                 if (typeof signature === 'function') {
                     signature.call(temporaryApi, exp.address);
-                    if (isObjCApi)
-                        signature.call(temporaryApi, exp.address);
                 } else {
                     temporaryApi[name] = new NativeFunction(exp.address, signature[0], signature[1], defaultInvocationOptions);
-                    if (isObjCApi)
-                        temporaryApi[name] = temporaryApi[name];
                 }
                 remaining--;
             } else {


### PR DESCRIPTION
These three statements were remnants of the factor-out that merged the separate cachedObjCApi subset into temporaryApi: a duplicated signature.call, a self-assignment, and the now-unused local.