### PR TITLE
Harden registry lookups and mark nullable runtime fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,13 +80,15 @@ declare module "frida-objc-bridge" {
 
             /**
              * Instance used for chaining up to super-class method implementations.
+             * `null` for root classes such as `NSObject`.
              */
-            $super: ObjC.Object;
+            $super: ObjC.Object | null;
 
             /**
-             * Super-class of this object's class.
+             * Super-class of this object's class. `null` for root classes such
+             * as `NSObject`.
              */
-            $superClass: ObjC.Object;
+            $superClass: ObjC.Object | null;
 
             /**
              * Class that this object is an instance of.

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ function Runtime() {
     ]);
 
     function ClassRegistry() {
-        const cachedClasses = {};
+        const cachedClasses = new Map();
         let numCachedClasses = 0;
 
         const registry = new Proxy(this, {
@@ -273,11 +273,11 @@ function Runtime() {
                     for (let i = 0; i !== numClasses; i++) {
                         const handle = classHandles.add(i * pointerSize).readPointer();
                         const name = api.class_getName(handle).readUtf8String();
-                        cachedClasses[name] = handle;
+                        cachedClasses.set(name, handle);
                     }
                     numCachedClasses = numClasses;
                 }
-                return Object.keys(cachedClasses);
+                return Array.from(cachedClasses.keys());
             },
             getOwnPropertyDescriptor(target, property) {
                 return {
@@ -302,12 +302,12 @@ function Runtime() {
         }
 
         function findClass(name) {
-            let handle = cachedClasses[name];
+            let handle = cachedClasses.get(name);
             if (handle === undefined) {
                 handle = api.objc_lookUpClass(Memory.allocUtf8String(name));
                 if (handle.isNull())
                     return null;
-                cachedClasses[name] = handle;
+                cachedClasses.set(name, handle);
                 numCachedClasses++;
             }
 
@@ -333,7 +333,7 @@ function Runtime() {
     }
 
     function ProtocolRegistry() {
-        let cachedProtocols = {};
+        const cachedProtocols = new Map();
         let numCachedProtocols = 0;
 
         const registry = new Proxy(this, {
@@ -370,19 +370,19 @@ function Runtime() {
                 try {
                     const numProtocols = numProtocolsBuf.readUInt();
                     if (numProtocols !== numCachedProtocols) {
-                        cachedProtocols = {};
+                        cachedProtocols.clear();
                         for (let i = 0; i !== numProtocols; i++) {
                             const handle = protocolHandles.add(i * pointerSize).readPointer();
                             const name = api.protocol_getName(handle).readUtf8String();
 
-                            cachedProtocols[name] = handle;
+                            cachedProtocols.set(name, handle);
                         }
                         numCachedProtocols = numProtocols;
                     }
                 } finally {
                     api.free(protocolHandles);
                 }
-                return Object.keys(cachedProtocols);
+                return Array.from(cachedProtocols.keys());
             },
             getOwnPropertyDescriptor(target, property) {
                 return {
@@ -400,12 +400,12 @@ function Runtime() {
         }
 
         function findProtocol(name) {
-            let handle = cachedProtocols[name];
+            let handle = cachedProtocols.get(name);
             if (handle === undefined) {
                 handle = api.objc_getProtocol(Memory.allocUtf8String(name));
                 if (handle.isNull())
                     return null;
-                cachedProtocols[name] = handle;
+                cachedProtocols.set(name, handle);
                 numCachedProtocols++;
             }
 
@@ -414,7 +414,7 @@ function Runtime() {
 
         function toJSON() {
             return Object.keys(registry).reduce(function (r, name) {
-                r[name] = { handle: cachedProtocols[name] };
+                r[name] = { handle: cachedProtocols.get(name) };
                 return r;
             }, {});
         }
@@ -463,7 +463,7 @@ function Runtime() {
         let cachedMethodNames = null;
         let cachedProtocolMethods = null;
         let respondsToSelector = null;
-        const cachedMethods = {};
+        const cachedMethods = new Map();
         let cachedNativeMethodNames = null;
         let cachedOwnMethodNames = null;
         let cachedIvars = null;
@@ -672,14 +672,14 @@ function Runtime() {
                                     jsNames[name] = true;
 
                                     const fullName = fullNamePrefix + nativeName;
-                                    if (cachedMethods[fullName] === undefined) {
+                                    if (!cachedMethods.has(fullName)) {
                                         const details = {
                                             sel: sel,
                                             handle: methodHandle,
                                             wrapper: null
                                         };
-                                        cachedMethods[fullName] = details;
-                                        cachedMethods[name] = details;
+                                        cachedMethods.set(fullName, details);
+                                        cachedMethods.set(name, details);
                                     }
                                 }
                             } finally {
@@ -750,16 +750,16 @@ function Runtime() {
         }
 
         function findMethod(rawName) {
-            let method = cachedMethods[rawName];
+            let method = cachedMethods.get(rawName);
             if (method !== undefined)
                 return method;
 
             const tokens = parseMethodName(rawName);
             const fullName = tokens[2];
 
-            method = cachedMethods[fullName];
+            method = cachedMethods.get(fullName);
             if (method !== undefined) {
-                cachedMethods[rawName] = method;
+                cachedMethods.set(rawName, method);
                 return method;
             }
 
@@ -829,10 +829,10 @@ function Runtime() {
                 }
             }
 
-            cachedMethods[fullName] = method;
-            cachedMethods[rawName] = method;
+            cachedMethods.set(fullName, method);
+            cachedMethods.set(rawName, method);
             if (kind === defaultKind)
-                cachedMethods[jsMethodName(name)] = method;
+                cachedMethods.set(jsMethodName(name), method);
 
             return method;
         }


### PR DESCRIPTION
Use null-prototype objects for the class and protocol caches so that inherited names like toString, __proto__, and isPrototypeOf no longer resolve through the prototype chain and get mistaken for registered classes.

Also declare mainQueue, $super, and $superClass as nullable in the type definitions, matching the runtime behaviour for uninitialized dispatch and root classes.